### PR TITLE
Fixing two small erros

### DIFF
--- a/pyazul/index.py
+++ b/pyazul/index.py
@@ -99,8 +99,7 @@ class AzulAPI:
         return self.azul_request(data, operation='ProcessPost')
 
     def verify_transaction(self, data):
-        data.update(validate.verify_transaction(
-            data, operation='VerifyPayment'))
+        data.update(validate.verify_transaction(data))
         return self.azul_request(data)
 
     def nulify_transaction(self, data):

--- a/pyazul/index.py
+++ b/pyazul/index.py
@@ -100,7 +100,7 @@ class AzulAPI:
 
     def verify_transaction(self, data):
         data.update(validate.verify_transaction(data))
-        return self.azul_request(data)
+        return self.azul_request(data, operation='VerifyPayment')
 
     def nulify_transaction(self, data):
         data.update(validate.nullify_transaction(data))

--- a/pyazul/validate.py
+++ b/pyazul/validate.py
@@ -104,7 +104,6 @@ def refund_transaction(data):
         'Amount': str(utils.clean_amount(data.get('Amount', 0))),
         'Itbis': utils.clean_amount(data.get('Itbis', 0)),
         'CurrencyPosCode': data.get('CurrencyPosCode', ''),
-        'OriginalDate': data.get('OriginalDate', ''),
         'OriginalTrxTicketNr': data.get('OriginalTrxTicketNr', ''),
         'AcquirerRefData': data.get('AcquirerRefData', '1'),
         'CustomerServicePhone': data.get('CustomerServicePhone', ''),


### PR DESCRIPTION
Fixes issue #5

# Rationale
- on index.verify_transaction: verify_transaction was being called with an unexpected parameter 'operator' and that said parameter wasn't being use 'on the other side'
- on validate.redund_transaction: the field 'OriginalDate' was duplicated inside the 'required' dict