### PR TITLE
Itbis can't default to 0, it should simply not be added to the payload.

### DIFF
--- a/pyazul/utils.py
+++ b/pyazul/utils.py
@@ -1,3 +1,13 @@
 def clean_amount(amount):
     amount = int(round(float(amount) * 100, 0))
     return amount
+
+# This function makes sure to not add 'Itbis' in the dict, unless there's a value.
+# Azul documentation doesn't specificy that it will fail if sent empty.
+def update_itbis(data):
+    if data.get('Itbis'):
+        temp = {
+            'Itbis': clean_amount(value),
+        }
+        data.update(temp)
+    return data

--- a/pyazul/validate.py
+++ b/pyazul/validate.py
@@ -31,7 +31,6 @@ def sale_transaction(data):
         'Payments': data.get('Payments', '1'),
         'Plan': data.get('Plan', '0'),
         'Amount': str(utils.clean_amount(data.get('Amount', 0))),
-        'Itbis': utils.clean_amount(data.get('Itbis', 0)),
         'CurrencyPosCode': data.get('CurrencyPosCode', ''),
         'AcquirerRefData': data.get('AcquirerRefData', '1'),
         'CustomerServicePhone': data.get('CustomerServicePhone', ''),
@@ -39,6 +38,9 @@ def sale_transaction(data):
         'EcommerceURL': data.get('EcommerceURL', ''),
         'CustomOrderID': data.get('CustomOrderID', ''),
     }
+
+    # We don't send Itbis in the dict, if there isn't any.
+    utils.update_itbis(required)
 
     return required
 
@@ -54,10 +56,12 @@ def hold_transaction(data):
         'Payments': data.get('Payments', '1'),
         'Plan': data.get('Plan', '0'),
         'Amount': utils.clean_amount(data.get('Amount', 0)),
-        'Itbis': utils.clean_amount(data.get('Itbis', 0)),
         'CurrencyPosCode': data.get('CurrencyPosCode', ''),
         'OrderNumber': data.get('OrderNumber', ''),
     }
+
+    # We don't send Itbis in the dict, if there isn't any.
+    utils.update_itbis(required)
 
     return required
 
@@ -66,8 +70,10 @@ def post_sale_transaction(data):
     required = {
         'AzulOrderId': data.get('AzulOrderId', ''),
         'Amount': utils.clean_amount(data.get('Amount', 0)),
-        'Itbis': utils.clean_amount(data.get('Itbis', 0)),
     }
+
+    # We don't send Itbis in the dict, if there isn't any.
+    utils.update_itbis(required)
 
     return required
 
@@ -83,11 +89,13 @@ def nullify_transaction(data):
         'Payments': data.get('Payments', '1'),
         'Plan': data.get('Plan', '0'),
         'Amount': utils.clean_amount(data.get('Amount', 0)),
-        'Itbis': utils.clean_amount(data.get('Itbis', 0)),
         'CurrencyPosCode': data.get('CurrencyPosCode', ''),
         'CustomerServicePhone': data.get('CustomerServicePhone', ''),
         'OrderNumber': data.get('OrderNumber', ''),
     }
+
+    # We don't send Itbis in the dict, if there isn't any.
+    utils.update_itbis(required)
 
     return required
 
@@ -102,7 +110,6 @@ def refund_transaction(data):
         'Payments': data.get('Payments', '1'),
         'Plan': data.get('Plan', '0'),
         'Amount': str(utils.clean_amount(data.get('Amount', 0))),
-        'Itbis': utils.clean_amount(data.get('Itbis', 0)),
         'CurrencyPosCode': data.get('CurrencyPosCode', ''),
         'OriginalDate': data.get('OriginalDate', ''),
         'OriginalTrxTicketNr': data.get('OriginalTrxTicketNr', ''),
@@ -114,6 +121,9 @@ def refund_transaction(data):
         'OriginalDate': data.get('OriginalDate', ''),
         'AzulOrderId': data.get('AzulOrderId', ''),
     }
+
+    # We don't send Itbis in the dict, if there isn't any.
+    utils.update_itbis(required)
 
     return required
 
@@ -134,7 +144,6 @@ def datavault_sale_transaction(data):
         'PosInputMode': data.get('PosInputMode', 'E-Commerce'),
         'TrxType': 'Sale',
         'Amount': utils.clean_amount(data.get('Amount', 0)),
-        'Itbis': utils.clean_amount(data.get('Itbis', 0)),
         'CurrencyPosCode': data.get('CurrencyPosCode', ''),
         'Payments': data.get('Payments', '1'),
         'Plan': data.get('Plan', '0'),
@@ -142,6 +151,9 @@ def datavault_sale_transaction(data):
         'OrderNumber': data.get('OrderNumber', ''),
         'DataVaultToken': data.get('DataVaultToken', ''),
     }
+
+    # We don't send Itbis in the dict, if there isn't any.
+    utils.update_itbis(required)
 
     return required
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/40803711/108601043-e296d800-7370-11eb-9ee7-4cb6dcb66adc.png)

According to the docs, 'Itbis' can be sent as 0 with no problems but it's been reported to fail when included. So, this PR makes it so it doesn't even include it in the payload in such cases.