### PR TITLE
dep: bump to python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=['requests'],
-    python_requires='>=3.6',
+    python_requires='>=3.9',
 )


### PR DESCRIPTION
## Motivation
Ya que Python 3.6 (antigua versión) ha llegado a su _"[end of life](https://devguide.python.org/versions/)"_, sería oportuno actualizar los requerimientos a una versión más actualizada que todavía tenga soporte de actualización por el equipo de _mantainers_ de Python.

## Describe your changes
Se cambió el requerimiento de la versión Python a `>=3.9` en el archivo `setup.py`.

## Issue ticket number and link
N/A
