### PR TITLE
[FEAT]: Add async support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ def sample_refund():
         "AuthorizationCode":"",
         "ResponseCode":"",
         "AcquirerRefData":"",
-        "RRN":null,
+        "RRN":"null",
         "AzulOrderId":40208,
         "CustomerServicePhone":"",
         "OrderNumber":"",
@@ -99,6 +99,46 @@ def sample_refund():
 
 ```
 
+## Async support
+Pyazul tambien es compatible con operaciones asíncronas de la siguiente manera:
+
+```python
+import asyncio
+# Import the Async module
+from pyazul import AzulAPIAsync
+
+# Make sure your function is async
+async def sample_sale():
+    auth1 = 'testcert2' # primer auth factor (se obtiene de Azul)
+    auth2 = 'testcert2' # segundo auth factor (se obtiene de Azul)
+    certificate_path = 'certificate.pem'
+    environment = 'prod' # defaults 'dev'
+    pyazul = AzulAPIAsync(auth1, auth2, certificate_path)
+    params = {
+        "Channel": "EC",
+        "Store": "37094649930",
+        "CardNumber": "",
+        "Expiration": "",
+        "CVC": "",
+        "PosInputMode": "E-Commerce",
+        "Amount": "12",
+        "CurrencyPosCode": "$",
+        "RNN": "null",
+        "CustomerServicePhone": "809-111-2222",
+        "OrderNumber": "SO039-2",
+        "ECommerceUrl": "azul.iterativo.do",
+        "CustomOrderId": "53",
+        "DataVaultToken": "74EAA676-FB9A-49E3-82CD-485DF85ECB61",
+        "ForceNo3DS": "1",
+        "SaveToDataVault": "0"
+    }
+    response = await pyazul.sale_transaction(params)
+
+# Test with asynccio
+if __name__ == "__main__":
+    asyncio.run(sample_sale())
+
+```
 ---
 
 &copy; LGPL License

--- a/pyazul/index.py
+++ b/pyazul/index.py
@@ -3,7 +3,7 @@ import json
 import logging
 
 # Third party packages
-import requests
+import httpx
 from . import validate
 
 _logger = logging.getLogger(__name__)
@@ -52,7 +52,7 @@ class AzulAPI:
         _logger.debug('azul_request: called with data:\n%s', data)
 
         try:
-            r = requests.post(
+            r = httpx.post(
                 azul_endpoint,
                 json=parameters,
                 headers=headers,
@@ -61,7 +61,7 @@ class AzulAPI:
             )
             if r.raise_for_status() and self.ENVIRONMENT == 'prod':
                 azul_endpoint = self.ALT_URL + f'?{operation}'
-                r = requests.post(
+                r = httpx.post(
                     azul_endpoint,
                     json=parameters,
                     headers=headers,
@@ -113,3 +113,91 @@ class AzulAPI:
     def datavault_delete(self, data):
         data.update(validate.datavault_delete(data))
         return self.azul_request(data, operation='ProcessDatavault')
+
+
+class AzulAPIAsync(AzulAPI):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    async def azul_request(self, data, operation=''):
+        #  Required parameters for all transactions
+        parameters = {
+            'Channel': data.get('Channel', ''),
+            'Store': data.get('Store', ''),
+        }
+
+        # Updating parameters with the extra parameters
+        parameters.update(data)
+
+        azul_endpoint = self.url + f'?{operation}'
+        cert_path = self.certificate_path
+
+        headers = {
+            'Content-Type': 'application/json',
+            'Auth1': self.auth1,
+            'Auth2': self.auth2,
+        }
+        r = {}
+        _logger.debug('azul_request: called with data:\n%s', data)
+
+        try:
+            async with httpx.AsyncClient(cert=cert_path) as client: 
+                r = await client.post(
+                    azul_endpoint,
+                    json=parameters,
+                    headers=headers,
+                    timeout=30,
+                )
+                if r.raise_for_status() and self.ENVIRONMENT == 'prod':
+                    azul_endpoint = self.ALT_URL + f'?{operation}'
+                    r = httpx.post(
+                        azul_endpoint,
+                        json=parameters,
+                        headers=headers,
+                        timeout=30,
+                    )
+        except Exception as err:
+            _logger.error(
+                'azul_request: Got the following error\n%s', str(err))
+            raise Exception(str(err))
+
+        response = json.loads(r.text)
+        _logger.debug('azul_request: Values received\n%s', json.loads(r.text))
+
+        return response
+
+    async def sale_transaction(self, data):
+        data.update(validate.sale_transaction(data))
+        return await self.azul_request(data)
+
+    async def hold_transaction(self, data):
+        data.update(validate.hold_transaction(data))
+        return await self.azul_request(data)
+
+    async def refund_transaction(self, data):
+        data.update(validate.refund_transaction(data))
+        return await self.azul_request(data)
+
+    async def void_transaction(self, data):
+        data.update(validate.void_transaction(data))
+        return await self.azul_request(data, operation='ProcessVoid')
+
+    async def post_sale_transaction(self, data):
+        data.update(validate.post_sale_transaction(data))
+        return await self.azul_request(data, operation='ProcessPost')
+
+    async def verify_transaction(self, data):
+        data.update(validate.verify_transaction(data))
+        return await self.azul_request(data, operation='VerifyPayment')
+
+    async def nulify_transaction(self, data):
+        data.update(validate.nullify_transaction(data))
+        return await self.azul_request(data)
+
+    async def datavault_create(self, data):
+        data.update(validate.datavault_create(data))
+        return await self.azul_request(data, operation='ProcessDatavault')
+
+    async def datavault_delete(self, data):
+        data.update(validate.datavault_delete(data))
+        return await self.azul_request(data, operation='ProcessDatavault')

--- a/pyazul/index.py
+++ b/pyazul/index.py
@@ -10,12 +10,13 @@ _logger = logging.getLogger(__name__)
 
 
 class AzulAPI:
-    def __init__(self, auth1, auth2, certificate_path, environment='dev'):
+    def __init__(self, auth1, auth2, certificate_path, custom_url=None, environment='dev'):
         '''
         :param auth1
         :param auth2
         :param certificate_path (path to your .p12 certificate)
         :param environment (string, defaults 'dev' can also be set to 'prod')
+        :param custom_url (string, defaults None, custom azul webservice url)
         '''
         self.certificate_path = (
             certificate_path  # TODO validate this is an actual certificate
@@ -24,11 +25,14 @@ class AzulAPI:
         self.auth2 = auth2
         self.ENVIRONMENT = environment
 
-        if environment == 'dev':
-            self.url = 'https://pruebas.azul.com.do/webservices/JSON/Default.aspx'
+        if custom_url:
+            self.url = custom_url
         else:
-            self.url = 'https://pagos.azul.com.do/webservices/JSON/Default.aspx'
-            self.ALT_URL = 'https://contpagos.azul.com.do/Webservices/JSON/default.aspx'
+            if environment == 'dev':
+                self.url = 'https://pruebas.azul.com.do/webservices/JSON/Default.aspx'
+            else:
+                self.url = 'https://pagos.azul.com.do/webservices/JSON/Default.aspx'
+                self.ALT_URL = 'https://contpagos.azul.com.do/Webservices/JSON/default.aspx'
 
     def azul_request(self, data, operation=''):
         #  Required parameters for all transactions
@@ -59,7 +63,7 @@ class AzulAPI:
                 cert=cert_path,
                 timeout=30,
             )
-            if r.raise_for_status() and self.ENVIRONMENT == 'prod':
+            if r.raise_for_status() and self.ENVIRONMENT == 'prod' and custom_url is None:
                 azul_endpoint = self.ALT_URL + f'?{operation}'
                 r = httpx.post(
                     azul_endpoint,

--- a/pyazul/requirements.txt
+++ b/pyazul/requirements.txt
@@ -1,2 +1,0 @@
-# Dependencies
-requests==2.22.0

--- a/pyazul/utils.py
+++ b/pyazul/utils.py
@@ -5,9 +5,9 @@ def clean_amount(amount):
 # This function makes sure to not add 'Itbis' in the dict, unless there's a value.
 # Azul documentation doesn't specificy that it will fail if sent empty.
 def update_itbis(data):
-    if data.get('Itbis'):
+    if (itbis := data.get('Itbis')):
         temp = {
-            'Itbis': clean_amount(value),
+            'Itbis': clean_amount(itbis),
         }
         data.update(temp)
     return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+anyio==4.0.0
+certifi==2023.7.22
+exceptiongroup==1.1.3
+h11==0.14.0
+httpcore==0.18.0
+httpx==0.25.0
+idna==3.4
+sniffio==1.3.0

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,6 @@ setuptools.setup(
         "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
         "Operating System :: OS Independent",
     ],
-    install_requires=['requests'],
+    install_requires=['httpx'],
     python_requires='>=3.9',
 )

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=['requests'],
-    python_requires='>=3.6',
+    python_requires='>=3.9',
 )


### PR DESCRIPTION
## Motivation
Desde el soporte de operaciones asíncronas mediante el paquete [AsyncIO](https://docs.python.org/3/library/asyncio.html) en Python 3.4, este paradigma ha dado la oportunidad de tomar ventajas de las operaciones _IO-Bound_, tales como el uso de paquetes con funcionalidades de comunicación mediante _HTTP_, por lo que sería un excelente feature incluir un cliente asíncrono para ser usado en microservicios basados en `asyncio`.

## Describe your changes
* Se eliminó el uso del paquete [`requests`](https://pypi.org/project/requests/) y se remplazó por [`httpx`](https://www.python-httpx.org/), esto porque `httpx` permite el uso tanto asíncrono como sincrónico y, además su API es [bastante compatible](https://www.python-httpx.org/compatibility/) con la del paquete de `requests`, por lo que la migración sería mínima y con poco esfuerzo.
* Se creó una clase llamada `AzulAPIAsync` con soporte a las operaciones asíncronas, la cual hereda de la clase principal `AzulAPI`.
* Se corrigió un pequeño _bug_ con una función del módulo `utils.py` llamada `update_itbis`.

> Nota: En dado caso de que exista la certeza de aprobar este cambio, considero importante añadir el soporte del API asíncrona a la documentación en el `README.md`, sin embargo, actualmente estoy sacando un tiempo muy limitado para contribuir en proyectos Open Source debido a otros compromisos, por lo que marcaré el PR como draft, hasta que termine la documentación propuesta para el _feature_. Las colaboraciones son bienvenidas tambien.

## Issue ticket number and link
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Added corresponding documentation.