### PR TITLE
[CI]: fix build and Pypi push workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,32 +1,51 @@
 name: Build & publish
 
 on:
-  push:
-    branches:
-      - master
-  create:
-    tags:
-      - v*
+  release:
+    types: [published]
 
 jobs:
-  build-n-publish:
-    name: Build and publish distributions 📦 to PyPI
-    runs-on: ubuntu-18.04
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, windows-2022, macos-11]
     steps:
-      - uses: actions/checkout@master
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+      - uses: actions/checkout@v4
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.16.0
+      - uses: actions/upload-artifact@v3
         with:
-          python-version: 3.7
-      - name: Build distribution 📦
-        run: |
-          python setup.py sdist
-      - name: Publish distribution 📦 to PyPI
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: pypa/gh-action-pypi-publish@master
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          # unpacks default artifact into dist/
+          # if `name: artifact` is omitted, the action will create extra parent dir
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN }}
-      # - name: Bump version and push tag
-      #   uses: mathieudutour/github-tag-action@v4.5
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation
Me fijé que los actions no están actualmente funcionando por el uso de `ubuntu-18.04`, el cual [ha sido descontinuado y removido](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/) en los Github Actions. Adicionalmente aproveché para sugerir algunos _approaches_ que están siendo utilizados actualmente para efectuar las operaciones que la versión anterior efectuaba pero de una manera más fácil.


## Describe your changes
 - Se cambió el trigger del action a `release`.
 - Se actualizó la versión de varios actions, tales como:
    * [`actions/checkout`](https://github.com/actions/checkout/releases/tag/v4.0.0)
    * [`pypa/gh-action-pypi-publish`](https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-)
 - Se utilizó el action de [`pypa/cibuildwheel`](https://github.com/pypa/cibuildwheel) para efectuar un _build_ compatible con las plataformas de Windows, Linux y MacOs. [Este fue el ejemplo utilizado como referencia](https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml).

## Issue ticket number and link
N/A

## Checklist before requesting a review
N/A