### PR TITLE
fix(3ds): session and field validation

### DIFF
--- a/docs/interrogate_badge.svg
+++ b/docs/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 97.1%</title>
+    <title>interrogate: 98.5%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">97.1%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">97.1%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">98.5%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">98.5%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyazul"
-version = "2.0.0"
+version = "2.1.0"
 description = "An Azul Webservices light wrapper for Python."
 authors = [{ name = "INDEXA Inc.", email = "info@indexa.do" }]
 license = { text = "MIT License" }

--- a/tests/integration/services/test_secure_integration.py
+++ b/tests/integration/services/test_secure_integration.py
@@ -209,21 +209,21 @@ async def test_secure_sale_frictionless_direct_approval(
     )
     assert initial_response_dict is not None
 
-    assert not initial_response_dict.get("redirect"), (
-        "Expected no redirect for direct frictionless approval."
-    )
+    assert not initial_response_dict.get(
+        "redirect"
+    ), "Expected no redirect for direct frictionless approval."
 
     value_data = initial_response_dict.get("value")
-    assert isinstance(value_data, dict), (
-        f"Expected 'value' dict in direct approval, got: {type(value_data)}"
-    )
+    assert isinstance(
+        value_data, dict
+    ), f"Expected 'value' dict in direct approval, got: {type(value_data)}"
 
-    assert value_data.get("IsoCode") == "00", (
-        f"Expected IsoCode 00, got: {value_data.get('IsoCode')}"
-    )
-    assert value_data.get("ResponseMessage") == "APROBADA", (
-        f"Expected APROBADA, got: {value_data.get('ResponseMessage')}"
-    )
+    assert (
+        value_data.get("IsoCode") == "00"
+    ), f"Expected IsoCode 00, got: {value_data.get('IsoCode')}"
+    assert (
+        value_data.get("ResponseMessage") == "APROBADA"
+    ), f"Expected APROBADA, got: {value_data.get('ResponseMessage')}"
     print("Approved directly (frictionless, no method/challenge redirect).")
 
 
@@ -269,9 +269,9 @@ async def test_secure_sale_direct_to_challenge(
         assert session_data is not None, "Session data not found."
         stored_term_url = session_data.get("term_url")
         assert stored_term_url is not None, "TermUrl not found."
-        assert f"secure_id={secure_id}" in stored_term_url, (
-            "secure_id not in stored TermUrl."
-        )
+        assert (
+            f"secure_id={secure_id}" in stored_term_url
+        ), "secure_id not in stored TermUrl."
 
         print("Direct challenge by secure_sale as expected.")
 
@@ -324,9 +324,9 @@ async def test_secure_sale_challenge_after_method(
     )
     assert initial_response_dict is not None
     assert initial_response_dict.get("redirect"), "Expected redirect for 3DS Method."
-    assert initial_response_dict.get("html") is not None, (
-        "HTML expected for 3DS Method."
-    )
+    assert (
+        initial_response_dict.get("html") is not None
+    ), "HTML expected for 3DS Method."
     assert initial_response_dict.get("id") is not None, "'id' (secure_id) expected."
 
     secure_id = initial_response_dict["id"]
@@ -347,14 +347,14 @@ async def test_secure_sale_challenge_after_method(
     assert isinstance(method_response, dict), "method_response should be dict."
 
     response_msg = method_response.get("ResponseMessage")
-    assert response_msg == "3D_SECURE_CHALLENGE", (
-        f"Expected 3D_SECURE_CHALLENGE, got {response_msg}"
-    )
+    assert (
+        response_msg == "3D_SECURE_CHALLENGE"
+    ), f"Expected 3D_SECURE_CHALLENGE, got {response_msg}"
 
     three_ds_challenge_data = method_response.get("ThreeDSChallenge")
-    assert isinstance(three_ds_challenge_data, dict), (
-        "ThreeDSChallenge data missing/not dict"
-    )
+    assert isinstance(
+        three_ds_challenge_data, dict
+    ), "ThreeDSChallenge data missing/not dict"
 
     creq = three_ds_challenge_data.get("CReq")
     redirect_post_url_from_acs = three_ds_challenge_data.get("RedirectPostUrl")
@@ -422,9 +422,9 @@ async def test_secure_sale_3ds_method_with_session_validation(
     azul_order_id = session_data["azul_order_id"]
 
     # Verify the session is accessible by the secure service
-    assert azul.secure.secure_sessions.get(secure_id) is not None, (
-        "Session should be accessible"
-    )
+    assert (
+        azul.secure.secure_sessions.get(secure_id) is not None
+    ), "Session should be accessible"
 
     # Step 4: Process 3DS method and validate it includes required fields
     method_response = await azul.process_3ds_method(
@@ -439,12 +439,12 @@ async def test_secure_sale_3ds_method_with_session_validation(
     if isinstance(method_response, dict):
         # Should not have errors about missing fields
         error_msg = method_response.get("ErrorDescription", "")
-        assert "Amount or currency missing" not in error_msg, (
-            f"Should not have missing field errors: {error_msg}"
-        )
-        assert "No autenticada" not in error_msg, (
-            f"Should not have auth errors: {error_msg}"
-        )
+        assert (
+            "Amount or currency missing" not in error_msg
+        ), f"Should not have missing field errors: {error_msg}"
+        assert (
+            "No autenticada" not in error_msg
+        ), f"Should not have auth errors: {error_msg}"
 
 
 @pytest.mark.asyncio
@@ -500,6 +500,6 @@ async def test_secure_sale_duplicate_method_notification_handling(
     )
 
     # Should indicate it was already processed
-    assert second_response.get("ResponseMessage") == "ALREADY_PROCESSED", (
-        "Duplicate method notification should be detected"
-    )
+    assert (
+        second_response.get("ResponseMessage") == "ALREADY_PROCESSED"
+    ), "Duplicate method notification should be detected"

--- a/tests/integration/services/test_secure_integration.py
+++ b/tests/integration/services/test_secure_integration.py
@@ -209,21 +209,21 @@ async def test_secure_sale_frictionless_direct_approval(
     )
     assert initial_response_dict is not None
 
-    assert not initial_response_dict.get(
-        "redirect"
-    ), "Expected no redirect for direct frictionless approval."
+    assert not initial_response_dict.get("redirect"), (
+        "Expected no redirect for direct frictionless approval."
+    )
 
     value_data = initial_response_dict.get("value")
-    assert isinstance(
-        value_data, dict
-    ), f"Expected 'value' dict in direct approval, got: {type(value_data)}"
+    assert isinstance(value_data, dict), (
+        f"Expected 'value' dict in direct approval, got: {type(value_data)}"
+    )
 
-    assert (
-        value_data.get("IsoCode") == "00"
-    ), f"Expected IsoCode 00, got: {value_data.get('IsoCode')}"
-    assert (
-        value_data.get("ResponseMessage") == "APROBADA"
-    ), f"Expected APROBADA, got: {value_data.get('ResponseMessage')}"
+    assert value_data.get("IsoCode") == "00", (
+        f"Expected IsoCode 00, got: {value_data.get('IsoCode')}"
+    )
+    assert value_data.get("ResponseMessage") == "APROBADA", (
+        f"Expected APROBADA, got: {value_data.get('ResponseMessage')}"
+    )
     print("Approved directly (frictionless, no method/challenge redirect).")
 
 
@@ -269,9 +269,9 @@ async def test_secure_sale_direct_to_challenge(
         assert session_data is not None, "Session data not found."
         stored_term_url = session_data.get("term_url")
         assert stored_term_url is not None, "TermUrl not found."
-        assert (
-            f"secure_id={secure_id}" in stored_term_url
-        ), "secure_id not in stored TermUrl."
+        assert f"secure_id={secure_id}" in stored_term_url, (
+            "secure_id not in stored TermUrl."
+        )
 
         print("Direct challenge by secure_sale as expected.")
 
@@ -324,9 +324,9 @@ async def test_secure_sale_challenge_after_method(
     )
     assert initial_response_dict is not None
     assert initial_response_dict.get("redirect"), "Expected redirect for 3DS Method."
-    assert (
-        initial_response_dict.get("html") is not None
-    ), "HTML expected for 3DS Method."
+    assert initial_response_dict.get("html") is not None, (
+        "HTML expected for 3DS Method."
+    )
     assert initial_response_dict.get("id") is not None, "'id' (secure_id) expected."
 
     secure_id = initial_response_dict["id"]
@@ -347,14 +347,14 @@ async def test_secure_sale_challenge_after_method(
     assert isinstance(method_response, dict), "method_response should be dict."
 
     response_msg = method_response.get("ResponseMessage")
-    assert (
-        response_msg == "3D_SECURE_CHALLENGE"
-    ), f"Expected 3D_SECURE_CHALLENGE, got {response_msg}"
+    assert response_msg == "3D_SECURE_CHALLENGE", (
+        f"Expected 3D_SECURE_CHALLENGE, got {response_msg}"
+    )
 
     three_ds_challenge_data = method_response.get("ThreeDSChallenge")
-    assert isinstance(
-        three_ds_challenge_data, dict
-    ), "ThreeDSChallenge data missing/not dict"
+    assert isinstance(three_ds_challenge_data, dict), (
+        "ThreeDSChallenge data missing/not dict"
+    )
 
     creq = three_ds_challenge_data.get("CReq")
     redirect_post_url_from_acs = three_ds_challenge_data.get("RedirectPostUrl")
@@ -374,3 +374,132 @@ async def test_secure_sale_challenge_after_method(
     assert "<form" in challenge_form_html and 'name="creq"' in challenge_form_html
 
     print("Challenge after 3DS Method initiated as expected.")
+
+
+@pytest.mark.asyncio
+async def test_secure_sale_3ds_method_with_session_validation(
+    azul_fixture: PyAzul,
+    card_holder_info_fixture: CardHolderInfo,
+    settings,
+):
+    """Test that 3DS method processing includes all required fields and maintains session state."""  # noqa: E501
+    azul = azul_fixture
+    card = get_card("SECURE_3DS_FRICTIONLESS_WITH_3DS")
+    order_num = generate_order_number()
+    base_dummy_url = "http://localhost:8000/dummy"
+
+    initial_request_data = _prepare_secure_sale_request_data(
+        settings=settings,
+        card=card,
+        order_num=order_num,
+        card_holder_info=card_holder_info_fixture,
+        challenge_indicator=ChallengeIndicator.NO_CHALLENGE,
+        custom_order_id_prefix="3ds-session-validation",
+        base_method_url=f"{base_dummy_url}/method",
+        base_term_url=f"{base_dummy_url}/term",
+        force_no_3ds_flag="0",
+        amount_value=1500,  # Use specific amount to validate
+        itbis_value=270,  # Use specific ITBIS to validate
+    )
+
+    # Step 1: Initial secure sale
+    initial_response_dict = await azul.secure_sale(
+        initial_request_data.model_dump(exclude_none=True)
+    )
+
+    assert initial_response_dict.get("redirect"), "Expected 3DS method redirect"
+    secure_id = initial_response_dict["id"]
+
+    # Step 2: Validate session data is properly stored
+    session_data = await azul.get_secure_session_info(secure_id)
+    assert session_data is not None, "Session data should be stored"
+    assert session_data.get("azul_order_id"), "AzulOrderId should be in session"
+    assert session_data.get("amount") == "1500", "Amount should be stored in session"
+    assert session_data.get("itbis") == "270", "ITBIS should be stored in session"
+    assert session_data.get("order_number") == order_num, "OrderNumber should be stored"
+
+    # Step 3: Validate that process_3ds_method can access session data
+    azul_order_id = session_data["azul_order_id"]
+
+    # Verify the session is accessible by the secure service
+    assert azul.secure.secure_sessions.get(secure_id) is not None, (
+        "Session should be accessible"
+    )
+
+    # Step 4: Process 3DS method and validate it includes required fields
+    method_response = await azul.process_3ds_method(
+        azul_order_id=azul_order_id,
+        method_notification_status="RECEIVED",
+    )
+
+    # The method should succeed (this validates that all required fields were sent)
+    assert method_response is not None, "Method response should not be None"
+
+    # If it's a successful response, validate the structure
+    if isinstance(method_response, dict):
+        # Should not have errors about missing fields
+        error_msg = method_response.get("ErrorDescription", "")
+        assert "Amount or currency missing" not in error_msg, (
+            f"Should not have missing field errors: {error_msg}"
+        )
+        assert "No autenticada" not in error_msg, (
+            f"Should not have auth errors: {error_msg}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_secure_sale_duplicate_method_notification_handling(
+    azul_fixture: PyAzul,
+    card_holder_info_fixture: CardHolderInfo,
+    settings,
+):
+    """Test that duplicate 3DS method notifications are handled properly."""
+    azul = azul_fixture
+    card = get_card("SECURE_3DS_FRICTIONLESS_WITH_3DS")
+    order_num = generate_order_number()
+    base_dummy_url = "http://localhost:8000/dummy"
+
+    initial_request_data = _prepare_secure_sale_request_data(
+        settings=settings,
+        card=card,
+        order_num=order_num,
+        card_holder_info=card_holder_info_fixture,
+        challenge_indicator=ChallengeIndicator.NO_CHALLENGE,
+        custom_order_id_prefix="3ds-duplicate-test",
+        base_method_url=f"{base_dummy_url}/method",
+        base_term_url=f"{base_dummy_url}/term",
+        force_no_3ds_flag="0",
+    )
+
+    # Step 1: Initial secure sale
+    initial_response_dict = await azul.secure_sale(
+        initial_request_data.model_dump(exclude_none=True)
+    )
+
+    if not initial_response_dict.get("redirect"):
+        pytest.skip("Test requires 3DS method redirect")
+
+    secure_id = initial_response_dict["id"]
+    session_data = await azul.get_secure_session_info(secure_id)
+    assert session_data is not None, "Session data should not be None"
+    azul_order_id = session_data["azul_order_id"]
+
+    # Step 2: First method notification
+    first_response = await azul.process_3ds_method(
+        azul_order_id=azul_order_id,
+        method_notification_status="RECEIVED",
+    )
+
+    # Validate first response is successful
+    assert first_response is not None, "First method response should not be None"
+
+    # Step 3: Duplicate method notification (should be handled gracefully)
+    second_response = await azul.process_3ds_method(
+        azul_order_id=azul_order_id,
+        method_notification_status="RECEIVED",
+    )
+
+    # Should indicate it was already processed
+    assert second_response.get("ResponseMessage") == "ALREADY_PROCESSED", (
+        "Duplicate method notification should be detected"
+    )

--- a/tests/unit/services/test_secure_service_unit.py
+++ b/tests/unit/services/test_secure_service_unit.py
@@ -171,6 +171,15 @@ async def test_process_sale_direct_approval(
 @pytest.mark.asyncio
 async def test_process_3ds_method(secure_service, mock_api_client):
     """Test process_3ds_method with successful response."""
+    # Set up session data for the azul_order_id
+    secure_service.secure_sessions["test_session"] = {
+        "azul_order_id": "12345",
+        "amount": "1000",
+        "itbis": "180",
+        "order_number": "TEST123",
+        "term_url": "https://example.com/post-3ds?secure_id=test_session",
+    }
+
     # Mock API response for 3DS method
     mock_api_client._async_request.return_value = {
         "ResponseMessage": "3D_SECURE_CHALLENGE",


### PR DESCRIPTION
- Add test_secure_sale_3ds_method_with_session_validation to verify session data storage and required field inclusion
- Add test_secure_sale_duplicate_method_notification_handling to test duplicate notification handling
- Validate that Amount, ITBIS, and OrderNumber are properly passed to processthreedsmethod operation
- Ensure session state is maintained between secure_sale and process_3ds_method calls
- Add assertions for authentication and missing field error scenarios

These tests would have caught the bugs we discovered in production where:
- Missing Amount/Currency fields caused "SGS-030056" errors
- Authentication headers weren't properly set for 3DS method requests
- Session data wasn't being restored between PyAzul method calls