### PR TITLE
fix(secure): resolve tokenization issues in 3DS flows

### DIFF
--- a/docs/interrogate_badge.svg
+++ b/docs/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 98.8%</title>
+    <title>interrogate: 98.9%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">98.8%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">98.8%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">98.9%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">98.9%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/pyazul/services/secure.py
+++ b/pyazul/services/secure.py
@@ -32,7 +32,7 @@ class SecureService:
         """Process a secure sale transaction with 3DS authentication."""
         secure_id = str(uuid4())
         logger.debug("=" * 50)
-        logger.debug(f"STARTING SECURE SALE PROCESS - ID: {secure_id}")
+        logger.debug("STARTING SECURE SALE PROCESS - ID: %s", secure_id)
         logger.debug("=" * 50)
 
         try:
@@ -58,6 +58,8 @@ class SecureService:
                 "Itbis": str(request_dict["Itbis"]),
                 "OrderNumber": request_dict["OrderNumber"],
                 "Currency": "DOP",
+                "CustomOrderId": request_dict.get("CustomOrderId", ""),
+                "SaveToDataVault": request_dict.get("SaveToDataVault", "0"),
                 "ThreeDSAuth": {
                     "TermUrl": term_url,
                     "MethodNotificationUrl": method_notification_url,
@@ -74,6 +76,7 @@ class SecureService:
             logger.debug("-" * 50)
             logger.debug(json.dumps(sale_data, indent=2))
             logger.debug("-" * 50)
+            # pylint: disable=protected-access
             result = await self.api._async_request(
                 data=sale_data,
                 is_secure=True,  # Indicate this is a 3DS request
@@ -128,7 +131,7 @@ class SecureService:
                 logger.debug("TRANSACTION APPROVED WITHOUT 3DS!")
                 return {"redirect": False, "id": secure_id, "value": result}
             else:
-                logger.warning(f"UNEXPECTED RESPONSE! Message: {response_message}")
+                logger.warning("UNEXPECTED RESPONSE! Message: %s", response_message)
                 logger.warning("Complete response:")
                 logger.debug(json.dumps(result, indent=2))
                 return {
@@ -139,7 +142,7 @@ class SecureService:
                 }
 
         except Exception as e:
-            logger.error(f"ERROR IN SALE PROCESS! {str(e)}")
+            logger.error("ERROR IN SALE PROCESS! %s", str(e))
             raise AzulError(f"Error processing secure sale: {str(e)}") from e
 
     async def process_token_sale(self, request: SecureTokenSale) -> Dict[str, Any]:
@@ -151,7 +154,7 @@ class SecureService:
         """
         secure_id = str(uuid4())
         logger.debug("=" * 50)
-        logger.debug(f"STARTING SECURE TOKEN SALE PROCESS - ID: {secure_id}")
+        logger.debug("STARTING SECURE TOKEN SALE PROCESS - ID: %s", secure_id)
         logger.debug("=" * 50)
 
         try:
@@ -193,6 +196,7 @@ class SecureService:
             logger.debug("-" * 50)
             logger.debug(json.dumps(sale_data, indent=2))
             logger.debug("-" * 50)
+            # pylint: disable=protected-access
             result = await self.api._async_request(data=sale_data, is_secure=True)
 
             # Detailed response logging
@@ -241,7 +245,7 @@ class SecureService:
                 logger.debug("TRANSACTION APPROVED WITHOUT 3DS!")
                 return {"redirect": False, "id": secure_id, "value": result}
             else:
-                logger.warning(f"UNEXPECTED RESPONSE! Message: {response_message}")
+                logger.warning("UNEXPECTED RESPONSE! Message: %s", response_message)
                 logger.warning("Complete response:")
                 logger.debug(json.dumps(result, indent=2))
                 return {
@@ -252,7 +256,7 @@ class SecureService:
                 }
 
         except Exception as e:
-            logger.error(f"ERROR IN SALE PROCESS! {str(e)}")
+            logger.error("ERROR IN SALE PROCESS! %s", str(e))
             raise AzulError(f"Error processing secure sale: {str(e)}") from e
 
     async def process_hold(self, request: SecureSaleRequest) -> Dict[str, Any]:
@@ -264,7 +268,7 @@ class SecureService:
         """
         secure_id = str(uuid4())
         logger.debug("=" * 50)
-        logger.debug(f"STARTING SECURE HOLD PROCESS - ID: {secure_id}")
+        logger.debug("STARTING SECURE HOLD PROCESS - ID: %s", secure_id)
         logger.debug("=" * 50)
 
         try:
@@ -290,6 +294,8 @@ class SecureService:
                 "Itbis": str(request_dict["Itbis"]),
                 "OrderNumber": request_dict["OrderNumber"],
                 "Currency": "DOP",
+                "CustomOrderId": request_dict.get("CustomOrderId", ""),
+                "SaveToDataVault": request_dict.get("SaveToDataVault", "0"),
                 "ThreeDSAuth": {
                     "TermUrl": term_url,
                     "MethodNotificationUrl": method_notification_url,
@@ -306,6 +312,7 @@ class SecureService:
             logger.debug("-" * 50)
             logger.debug(json.dumps(hold_data, indent=2))
             logger.debug("-" * 50)
+            # pylint: disable=protected-access
             result = await self.api._async_request(
                 data=hold_data,
                 is_secure=True,  # Indicate this is a 3DS request
@@ -360,7 +367,7 @@ class SecureService:
                 logger.debug("TRANSACTION APPROVED WITHOUT 3DS!")
                 return {"redirect": False, "id": secure_id, "value": result}
             else:
-                logger.warning(f"UNEXPECTED RESPONSE! Message: {response_message}")
+                logger.warning("UNEXPECTED RESPONSE! Message: %s", response_message)
                 logger.warning("Complete response:")
                 logger.debug(json.dumps(result, indent=2))
                 return {
@@ -371,7 +378,7 @@ class SecureService:
                 }
 
         except Exception as e:
-            logger.error(f"ERROR IN HOLD PROCESS! {str(e)}")
+            logger.error("ERROR IN HOLD PROCESS! %s", str(e))
             raise AzulError(f"Error processing secure hold: {str(e)}") from e
 
     async def process_3ds_method(
@@ -403,7 +410,7 @@ class SecureService:
 
             if not session_data:
                 logger.error(
-                    f"No session data found for azul_order_id: {azul_order_id}"
+                    "No session data found for azul_order_id: %s", azul_order_id
                 )
                 return {
                     "ResponseMessage": "SESSION_NOT_FOUND",
@@ -430,6 +437,7 @@ class SecureService:
             logger.debug(json.dumps(data, indent=2))
             logger.debug("-" * 50)
 
+            # pylint: disable=protected-access
             result = await self.api._async_request(
                 data, operation="processthreedsmethod", is_secure=True
             )
@@ -464,7 +472,7 @@ class SecureService:
         # Check current transaction state
         current_state = self.transaction_states.get(azul_order_id)
         if current_state != "3D_SECURE_CHALLENGE":
-            logger.warning(f"Unexpected state for 3DS challenge: {current_state}")
+            logger.warning("Unexpected state for 3DS challenge: %s", current_state)
             logger.warning("Waiting 2 seconds before continuing...")
             await asyncio.sleep(2)  # Wait a bit before continuing
 
@@ -476,9 +484,9 @@ class SecureService:
         }
 
         logger.debug("INITIATING 3DS CHALLENGE PROCESS...")
-        logger.debug(f"Session ID: {secure_id}")
-        logger.debug(f"Order ID: {azul_order_id}")
-        logger.debug(f"Current state: {current_state}")
+        logger.debug("Session ID: %s", secure_id)
+        logger.debug("Order ID: %s", azul_order_id)
+        logger.debug("Current state: %s", current_state)
         logger.debug("=" * 50)
 
         logger.debug("SENDING REQUEST TO AZUL WITH 3DS CHALLENGE NOTIFICATION...")
@@ -487,6 +495,7 @@ class SecureService:
         logger.debug("-" * 50)
 
         try:
+            # pylint: disable=protected-access
             result = await self.api._async_request(
                 data, operation="processthreedschallenge", is_secure=True
             )
@@ -502,10 +511,10 @@ class SecureService:
                 if "Wrong transaction state" in result["ErrorDescription"]:
                     logger.error("Transaction state error:")
                     logger.error(
-                        f"- Current state: {result.get('TransactionState', 'Unknown')}"
+                        "- Current state: %s", result.get("TransactionState", "Unknown")
                     )
-                    logger.error(f"- Error code: {result.get('ErrorCode', 'Unknown')}")
-                    logger.error(f"- Description: {result['ErrorDescription']}")
+                    logger.error("- Error code: %s", result.get("ErrorCode", "Unknown"))
+                    logger.error("- Description: %s", result["ErrorDescription"])
 
                     # Return a more friendly message
                     result["ErrorDescription"] = (
@@ -516,7 +525,7 @@ class SecureService:
             return result
 
         except Exception as e:
-            logger.error(f"Error processing 3DS challenge: {str(e)}")
+            logger.error("Error processing 3DS challenge: %s", str(e))
             error_msg = str(e)
 
             # Improve error message for user

--- a/tests/integration/services/test_datavault_integration.py
+++ b/tests/integration/services/test_datavault_integration.py
@@ -4,7 +4,14 @@ from typing import Literal
 
 import pytest
 
+from pyazul import PyAzul
 from pyazul.models import DataVaultRequestModel, TokenSaleModel
+from pyazul.models.secure import (
+    CardHolderInfo,
+    ChallengeIndicator,
+    SecureTokenSale,
+    ThreeDSAuth,
+)
 from tests.fixtures.cards import get_card
 from tests.fixtures.order import generate_order_number
 
@@ -30,6 +37,38 @@ def datavault_create_data(settings):
         "Expiration": card["expiration"],
         "CVC": None,  # Optional for CREATE, some card fixtures might have it
     }
+
+
+@pytest.fixture
+def card_holder_info_fixture() -> CardHolderInfo:
+    """Provide a standard CardHolderInfo object for 3DS tests."""
+    return CardHolderInfo(
+        BillingAddressCity="Santo Domingo",
+        BillingAddressCountry="DO",
+        BillingAddressLine1="Test Address 123",
+        BillingAddressLine2=None,
+        BillingAddressLine3=None,
+        BillingAddressState="Distrito Nacional",
+        BillingAddressZip="10101",
+        Email="test@example.com",
+        Name="Test Cardholder",
+        PhoneHome=None,
+        PhoneMobile=None,
+        PhoneWork=None,
+        ShippingAddressCity="Santo Domingo",
+        ShippingAddressCountry="DO",
+        ShippingAddressLine1="Test Shipping Address 456",
+        ShippingAddressLine2=None,
+        ShippingAddressLine3=None,
+        ShippingAddressState="Distrito Nacional",
+        ShippingAddressZip="10102",
+    )
+
+
+@pytest.fixture
+def azul_client(settings) -> PyAzul:
+    """Provide a PyAzul instance for 3DS token tests."""
+    return PyAzul(settings=settings)
 
 
 @pytest.mark.asyncio
@@ -72,7 +111,7 @@ async def test_create_sale_datavault(
     transaction_service_integration, completed_datavault_creation, settings
 ):
     """
-    Test sale transaction using a previously created token.
+    Test sale transaction using a previously created token (NON-3DS).
 
     Verifies that a token can be used for payment processing.
     """
@@ -86,7 +125,7 @@ async def test_create_sale_datavault(
         # BaseTransactionAttributes (PosInputMode, AcquirerRefData use defaults)
         "OrderNumber": generate_order_number(),
         "CustomOrderId": f"token-sale-{generate_order_number()}",
-        "ForceNo3DS": "1",  # Test specific
+        "ForceNo3DS": "1",  # Test specific - NON-3DS
         # TokenSaleModel specific fields (TrxType uses model default "Sale")
         "Amount": "1000",
         "Itbis": "180",
@@ -100,6 +139,155 @@ async def test_create_sale_datavault(
     print("Token used:", token)
     print("Response:", response)
     return response
+
+
+@pytest.mark.asyncio
+async def test_create_sale_datavault_3ds(
+    azul_client, completed_datavault_creation, card_holder_info_fixture, settings
+):
+    """
+    Test sale transaction using a previously created token (WITH 3DS).
+
+    This test validates that 3DS token sales work correctly and would catch
+    bugs like missing SaveToDataVault field in 3DS flows.
+    """
+    print(f"Completed Datavault for 3DS Sale: {completed_datavault_creation}")
+    token = completed_datavault_creation.get("DataVaultToken")
+
+    base_dummy_url = "http://localhost:8000/dummy"
+
+    # Create 3DS token sale request
+    token_sale_request = SecureTokenSale(
+        Store=settings.MERCHANT_ID,
+        Channel=settings.CHANNEL,
+        OrderNumber=generate_order_number(),
+        CustomOrderId=f"token-3ds-sale-{generate_order_number()}",
+        Amount="1000",
+        Itbis="180",
+        DataVaultToken=token,
+        CVC="123",  # Some providers require CVC even with tokens
+        forceNo3DS="0",  # Enable 3DS
+        cardHolderInfo=card_holder_info_fixture,
+        threeDSAuth=ThreeDSAuth(
+            TermUrl=f"{base_dummy_url}/term",
+            MethodNotificationUrl=f"{base_dummy_url}/method",
+            RequestChallengeIndicator=ChallengeIndicator.NO_CHALLENGE,
+        ),
+        PosInputMode="E-Commerce",
+        TrxType="Sale",
+        AcquirerRefData="1",
+    )
+
+    # Process the 3DS token sale
+    result = await azul_client.secure_token_sale(
+        token_sale_request.model_dump(exclude_none=True)
+    )
+
+    assert result is not None, "3DS token sale result should not be None"
+
+    # Handle different possible outcomes
+    if result.get("redirect"):
+        # 3DS method or challenge required
+        secure_id = result["id"]
+        print(f"3DS token sale initiated with redirect. ID: {secure_id}")
+
+        # This validates that the initial request was successful
+        # (if SaveToDataVault was missing, we'd get an error here)
+        assert "html" in result, "HTML form should be provided for redirect"
+
+    elif result.get("value") and isinstance(result["value"], dict):
+        # Direct approval (frictionless)
+        response = result["value"]
+        assert response.get("IsoCode") == "00", f"3DS token sale failed: {response}"
+        assert response.get("ResponseMessage") == "APROBADA"
+        print(f"3DS token sale approved directly: {response.get('AuthorizationCode')}")
+
+    else:
+        pytest.fail(f"Unexpected 3DS token sale result: {result}")
+
+    print("3DS token sale completed successfully")
+    return result
+
+
+@pytest.mark.asyncio
+async def test_token_sale_comparison_3ds_vs_non_3ds(
+    transaction_service_integration,
+    azul_client,
+    completed_datavault_creation,
+    card_holder_info_fixture,
+    settings,
+):
+    """
+    Compare token sales with and without 3DS to ensure both work correctly.
+
+    This test validates that both flows work and would catch integration bugs
+    that affect only one of the flows.
+    """
+    token = completed_datavault_creation.get("DataVaultToken")
+
+    # Test 1: Non-3DS token sale
+    print("Testing Non-3DS token sale...")
+    non_3ds_data = {
+        "Store": settings.MERCHANT_ID,
+        "Channel": settings.CHANNEL,
+        "OrderNumber": generate_order_number(),
+        "CustomOrderId": f"compare-no3ds-{generate_order_number()}",
+        "ForceNo3DS": "1",  # Disable 3DS
+        "Amount": "1000",
+        "Itbis": "180",
+        "DataVaultToken": token,
+        "CVC": None,
+    }
+
+    non_3ds_payment = TokenSaleModel(**non_3ds_data)
+    non_3ds_response = await transaction_service_integration.sale(non_3ds_payment)
+
+    assert (
+        non_3ds_response.get("IsoCode") == "00"
+    ), f"Non-3DS failed: {non_3ds_response}"
+    print(f"Non-3DS token sale: {non_3ds_response.get('AuthorizationCode')}")
+
+    # Test 2: 3DS token sale
+    print("Testing 3DS token sale...")
+    base_dummy_url = "http://localhost:8000/dummy"
+
+    three_ds_request = SecureTokenSale(
+        Store=settings.MERCHANT_ID,
+        Channel=settings.CHANNEL,
+        OrderNumber=generate_order_number(),
+        CustomOrderId=f"compare-3ds-{generate_order_number()}",
+        Amount="1000",
+        Itbis="180",
+        DataVaultToken=token,
+        CVC="123",
+        forceNo3DS="0",  # Enable 3DS
+        cardHolderInfo=card_holder_info_fixture,
+        threeDSAuth=ThreeDSAuth(
+            TermUrl=f"{base_dummy_url}/term",
+            MethodNotificationUrl=f"{base_dummy_url}/method",
+            RequestChallengeIndicator=ChallengeIndicator.NO_CHALLENGE,
+        ),
+        PosInputMode="E-Commerce",
+        TrxType="Sale",
+        AcquirerRefData="1",
+    )
+
+    three_ds_result = await azul_client.secure_token_sale(
+        three_ds_request.model_dump(exclude_none=True)
+    )
+
+    assert three_ds_result is not None, "3DS token sale should not be None"
+
+    if three_ds_result.get("redirect"):
+        print(f"3DS token sale initiated: {three_ds_result['id']}")
+    elif three_ds_result.get("value") and isinstance(three_ds_result["value"], dict):
+        response = three_ds_result["value"]
+        assert response.get("IsoCode") == "00", f"3DS failed: {response}"
+        print(f"3DS token sale approved: {response.get('AuthorizationCode')}")
+    else:
+        pytest.fail(f"Unexpected 3DS result: {three_ds_result}")
+
+    print("Both 3DS and non-3DS token sales work correctly")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Add missing SaveToDataVault field in PyAzul 3DS token operations
- Set tokenize flag in Odoo payment controller when save_card requested
- Fix tokenization validation in notification processing
- Add comprehensive unit and integration tests for 3DS token flows

Fixes tokenization not working during 3D Secure authentication flows.