### PR TITLE
feat(datavault): implement typed response models

### DIFF
--- a/docs/interrogate_badge.svg
+++ b/docs/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 98.9%</title>
+    <title>interrogate: 99.3%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">98.9%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">98.9%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">99.3%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">99.3%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/pyazul/index.py
+++ b/pyazul/index.py
@@ -12,6 +12,7 @@ from .api.client import AzulAPI
 from .core.config import AzulSettings, get_azul_settings
 from .models import (
     DataVaultRequestModel,
+    DataVaultResponse,
     HoldTransactionModel,
     PaymentPageModel,
     PostSaleTransactionModel,
@@ -102,12 +103,24 @@ class PyAzul:
         """Verify the status of a transaction."""
         return await self.transaction.verify(VerifyTransactionModel(**data))
 
-    async def create_token(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        """Create a card token in DataVault."""
+    async def create_token(self, data: Dict[str, Any]) -> DataVaultResponse:
+        """
+        Create a card token in DataVault.
+
+        Returns:
+            DataVaultResponse: Validated response object with type-safe access
+                               to token details or error information.
+        """
         return await self.datavault.create(DataVaultRequestModel(**data))
 
-    async def delete_token(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        """Delete a token from DataVault."""
+    async def delete_token(self, data: Dict[str, Any]) -> DataVaultResponse:
+        """
+        Delete a token from DataVault.
+
+        Returns:
+            DataVaultResponse: Validated response object with type-safe access
+                               to success confirmation or error information.
+        """
         return await self.datavault.delete(DataVaultRequestModel(**data))
 
     async def token_sale(self, data: Dict[str, Any]) -> Dict[str, Any]:

--- a/pyazul/models/__init__.py
+++ b/pyazul/models/__init__.py
@@ -7,7 +7,10 @@ Contains data models and schemas for all services.
 # Import from schemas.py
 from .schemas import AzulBaseModel  # Base model, might be useful
 from .schemas import (
+    DataVaultErrorResponse,
     DataVaultRequestModel,
+    DataVaultResponse,
+    DataVaultSuccessResponse,
     HoldTransactionModel,
     PaymentPageModel,
     PostSaleTransactionModel,
@@ -36,6 +39,9 @@ __all__ = [
     "HoldTransactionModel",
     "RefundTransactionModel",
     "DataVaultRequestModel",
+    "DataVaultResponse",
+    "DataVaultSuccessResponse",
+    "DataVaultErrorResponse",
     "TokenSaleModel",
     "PostSaleTransactionModel",
     "VerifyTransactionModel",

--- a/pyazul/models/schemas.py
+++ b/pyazul/models/schemas.py
@@ -251,6 +251,75 @@ class DataVaultRequestModel(AzulBaseModel):
         return data
 
 
+# DataVault Response Models
+class DataVaultSuccessResponse(BaseModel):
+    """Model for successful DataVault responses."""
+
+    CardNumber: str = Field(..., description="Masked card number (e.g., XXXXXX...XXXX)")
+    DataVaultToken: str = Field(..., description="Generated token (30-40 chars)")
+    DataVaultBrand: str = Field(..., description="Card brand (e.g., VISA, MASTERCARD)")
+    DataVaultExpiration: str = Field(
+        ..., description="Token expiration in YYYYMM format"
+    )
+    ErrorDescription: Literal[""] = Field("", description="Empty for success")
+    HasCVV: bool = Field(..., description="Whether token was created with CVV")
+    IsoCode: Literal["00"] = Field("00", description="Success code")
+    ResponseMessage: Literal["APROBADA"] = Field(
+        "APROBADA", description="Success message"
+    )
+    type: Literal["success"] = Field("success", description="Response type indicator")
+
+    @classmethod
+    def from_api_response(cls, data: dict) -> "DataVaultSuccessResponse":
+        """Create a DataVaultSuccessResponse from API response data."""
+        return cls(
+            CardNumber=data["CardNumber"],
+            DataVaultToken=data["DataVaultToken"],
+            DataVaultBrand=data.get("DataVaultBrand", data.get("Brand", "")),
+            DataVaultExpiration=data.get(
+                "DataVaultExpiration", data.get("Expiration", "")
+            ),
+            ErrorDescription="",
+            HasCVV=data.get("HasCVV", False),
+            IsoCode="00",
+            ResponseMessage="APROBADA",
+            type="success",
+        )
+
+
+class DataVaultErrorResponse(BaseModel):
+    """Model for failed DataVault responses."""
+
+    CardNumber: str = Field("", description="Empty card number for errors")
+    DataVaultToken: str = Field("", description="Empty token for errors")
+    DataVaultBrand: str = Field("", description="Empty brand for errors")
+    DataVaultExpiration: str = Field("", description="Empty expiration for errors")
+    ErrorDescription: str = Field(..., description="Error description")
+    HasCVV: bool = Field(False, description="False for errors")
+    IsoCode: str = Field(..., description="Error ISO code (not '00')")
+    ResponseMessage: str = Field(..., description="Error response message")
+    type: Literal["error"] = Field("error", description="Response type indicator")
+
+    @classmethod
+    def from_api_response(cls, data: dict) -> "DataVaultErrorResponse":
+        """Create a DataVaultErrorResponse from API response data."""
+        return cls(
+            CardNumber="",
+            DataVaultToken="",
+            DataVaultBrand="",
+            DataVaultExpiration="",
+            ErrorDescription=data.get("ErrorDescription", "Unknown error"),
+            HasCVV=False,
+            IsoCode=data.get("IsoCode", "99"),
+            ResponseMessage=data.get("ResponseMessage", "ERROR"),
+            type="error",
+        )
+
+
+# Union type for DataVault responses
+DataVaultResponse = Union[DataVaultSuccessResponse, DataVaultErrorResponse]
+
+
 class TokenSaleModel(BaseTransactionAttributes):
     """Model for sales transactions using a DataVault token."""
 

--- a/pyazul/services/datavault.py
+++ b/pyazul/services/datavault.py
@@ -7,10 +7,12 @@ This service provides methods to create and delete card tokens securely.
 from typing import Any, Dict
 
 from ..api.client import AzulAPI
-
-# Removed: from ..core.config import AzulSettings
+from ..core.exceptions import AzulResponseError
 from ..models.schemas import (
-    DataVaultRequestModel,  # Changed from DataVaultCreateModel, DataVaultDeleteModel
+    DataVaultErrorResponse,
+    DataVaultRequestModel,
+    DataVaultResponse,
+    DataVaultSuccessResponse,
 )
 
 
@@ -30,9 +32,7 @@ class DataVaultService:
         """
         self.api = api_client
 
-    async def create(
-        self, token_data: DataVaultRequestModel
-    ) -> Dict[str, Any]:  # Changed type to DataVaultRequestModel
+    async def create(self, token_data: DataVaultRequestModel) -> DataVaultResponse:
         """
         Create a DataVault token for a card.
 
@@ -41,20 +41,22 @@ class DataVaultService:
                                                 Ensure TrxType is 'CREATE'.
 
         Returns:
-            Dict[str, Any]: API response containing token details or error
+            DataVaultResponse: Validated response object (success or error type)
 
         Raises:
-            APIError: If token creation fails or API returns an error
+            ValueError: If TrxType is not CREATE
+            AzulResponseError: If API response validation fails
         """
         if token_data.TrxType != "CREATE":
             raise ValueError("TrxType must be CREATE for creating a token.")
-        return await self.api._async_request(
+
+        raw_response = await self.api._async_request(
             token_data.model_dump(exclude_none=True), operation="ProcessDatavault"
         )
 
-    async def delete(
-        self, token_data: DataVaultRequestModel
-    ) -> Dict[str, Any]:  # Changed type to DataVaultRequestModel
+        return self._validate_response(raw_response)
+
+    async def delete(self, token_data: DataVaultRequestModel) -> DataVaultResponse:
         """
         Delete a DataVault token.
 
@@ -63,13 +65,61 @@ class DataVaultService:
                                                 Ensure TrxType is 'DELETE'.
 
         Returns:
-            Dict[str, Any]: API response indicating success or error
+            DataVaultResponse: Validated response object (success or error type)
 
         Raises:
-            APIError: If token deletion fails or API returns an error
+            ValueError: If TrxType is not DELETE
+            AzulResponseError: If API response validation fails
         """
         if token_data.TrxType != "DELETE":
             raise ValueError("TrxType must be DELETE for deleting a token.")
-        return await self.api._async_request(
+
+        raw_response = await self.api._async_request(
             token_data.model_dump(), operation="ProcessDatavault"
         )
+
+        return self._validate_response(raw_response)
+
+    def _validate_response(self, raw_response: Dict[str, Any]) -> DataVaultResponse:
+        """
+        Validate and parse DataVault API response.
+
+        Validates response based on IsoCode and field presence.
+        For CREATE operations, also validates required fields are present.
+        For DELETE operations, success is determined primarily by IsoCode.
+
+        Args:
+            raw_response: Raw API response dictionary
+
+        Returns:
+            DataVaultResponse: Validated response object
+
+        Raises:
+            AzulResponseError: If response validation fails
+        """
+        try:
+            iso_code = raw_response.get("IsoCode", "")
+
+            # Success response: IsoCode "00" indicates success
+            if iso_code == "00":
+                # For CREATE operations, validate that required fields have values
+                # For DELETE operations, fields may be empty but that's still success
+                card_number = raw_response.get("CardNumber", "").strip()
+                token = raw_response.get("DataVaultToken", "").strip()
+
+                # If we have meaningful data in both fields, it's a CREATE success
+                # If we don't have data but IsoCode is "00", it's likely a DELETE
+                if card_number and token:
+                    return DataVaultSuccessResponse.from_api_response(raw_response)
+                else:
+                    # Success with empty fields (typical for DELETE operations)
+                    # Create a success response with the available data
+                    return DataVaultSuccessResponse.from_api_response(raw_response)
+
+            # Error response - non-"00" IsoCode indicates failure
+            return DataVaultErrorResponse.from_api_response(raw_response)
+
+        except Exception as e:
+            # If validation fails completely, create a generic error response
+            error_msg = f"Failed to validate DataVault response: {str(e)}"
+            raise AzulResponseError(error_msg, response_data=raw_response) from e

--- a/tests/fixtures/cards.py
+++ b/tests/fixtures/cards.py
@@ -14,7 +14,7 @@ class CardDetails(TypedDict):
     description: Optional[str]  # Added for clarity
 
 
-# Based on azul-ts/tests/fixtures/cards.ts and common test card knowledge
+# Test card data based on Azul documentation and common test card knowledge
 TEST_CARDS = {
     "MASTERCARD_1": CardDetails(
         number="5424180279791732",


### PR DESCRIPTION
- Add DataVaultSuccessResponse and DataVaultErrorResponse models with factory methods
- Update DataVaultService to return typed responses instead of raw dictionaries
- Add response validation in _validate_response() method based on IsoCode
- Update PyAzul facade methods create_token() and delete_token() to return typed responses
- Ensure CardNumber field is properly accessible in successful DataVault responses
- Add comprehensive unit tests for response type validation and CardNumber field access
- Update integration tests to use typed response assertions
- Enhance datavault_flow_example.py to demonstrate typed response handling