### PR TITLE
feat(secure): add SecureTokenHold functionality

### DIFF
--- a/docs/interrogate_badge.svg
+++ b/docs/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 99.6%</title>
+    <title>interrogate: 99.4%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">99.6%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">99.6%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">99.4%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">99.4%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/docs/interrogate_badge.svg
+++ b/docs/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 99.4%</title>
+    <title>interrogate: 99.0%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">99.4%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">99.4%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">99.0%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">99.0%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/pyazul/index.py
+++ b/pyazul/index.py
@@ -13,7 +13,7 @@ from .core.config import AzulSettings, get_azul_settings
 from .models.datavault import TokenRequest, TokenResponse, TokenSale
 from .models.payment import Hold, Post, Refund, Sale, Void
 from .models.payment_page import PaymentPage
-from .models.three_ds import SecureSale, SecureTokenSale
+from .models.three_ds import SecureSale, SecureTokenHold, SecureTokenSale
 from .models.verification import VerifyTransaction
 from .services.datavault import DataVaultService
 from .services.payment_page import PaymentPageService
@@ -136,6 +136,10 @@ class PyAzul:
         """Perform a hold on a card (pre-authorization) with 3D Secure."""
         # SecureService process_hold expects SecureSale model
         return await self.secure.process_hold(SecureSale(**data))
+
+    async def secure_token_hold(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Perform a hold on a saved token (pre-authorization) with 3D Secure."""
+        return await self.secure.process_token_hold(SecureTokenHold(**data))
 
     async def process_3ds_method(
         self, azul_order_id: str, method_notification_status: str

--- a/pyazul/models/three_ds/__init__.py
+++ b/pyazul/models/three_ds/__init__.py
@@ -10,6 +10,7 @@ from .models import (
     ChallengeIndicator,
     ChallengeRequest,
     SecureSale,
+    SecureTokenHold,
     SecureTokenSale,
     SessionID,
     ThreeDSAuth,
@@ -21,6 +22,7 @@ __all__ = [
     "ChallengeIndicator",
     "SecureSale",
     "SecureTokenSale",
+    "SecureTokenHold",
     "SessionID",
     "ChallengeRequest",
 ]

--- a/pyazul/services/secure.py
+++ b/pyazul/services/secure.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, Optional, Union
 from ..api.client import AzulAPI
 from ..core.config import AzulSettings
 from ..core.exceptions import AzulError
-from ..models.three_ds import SecureSale, SecureTokenSale
+from ..models.three_ds import SecureSale, SecureTokenHold, SecureTokenSale
 
 _logger = logging.getLogger(__name__)
 
@@ -161,7 +161,7 @@ class SecureService:
 
     def _prepare_secure_request_data(
         self,
-        request: Union[SecureSale, SecureTokenSale],
+        request: Union[SecureSale, SecureTokenSale, SecureTokenHold],
         secure_id: str,
         transaction_type: str = "Sale",
     ) -> tuple[Dict[str, Any], str]:
@@ -189,7 +189,7 @@ class SecureService:
     def _create_session_data(
         self,
         response: Dict[str, Any],
-        request: Union[SecureSale, SecureTokenSale],
+        request: Union[SecureSale, SecureTokenSale, SecureTokenHold],
         term_url: str,
         transaction_type: str = "sale",
     ) -> Dict[str, Any]:
@@ -259,7 +259,7 @@ class SecureService:
 
     async def _process_secure_transaction(
         self,
-        request: Union[SecureSale, SecureTokenSale],
+        request: Union[SecureSale, SecureTokenSale, SecureTokenHold],
         transaction_type: str,
         transaction_name: str,
     ) -> Dict[str, Any]:
@@ -305,6 +305,10 @@ class SecureService:
     async def process_hold(self, request: SecureSale) -> Dict[str, Any]:
         """Process a 3D Secure hold transaction."""
         return await self._process_secure_transaction(request, "Hold", "hold")
+
+    async def process_token_hold(self, request: SecureTokenHold) -> Dict[str, Any]:
+        """Process a 3D Secure token hold transaction."""
+        return await self._process_secure_transaction(request, "Hold", "token hold")
 
     async def process_3ds_method(
         self, azul_order_id: str, method_notification_status: str

--- a/tests/e2e/services/test_hold_integration.py
+++ b/tests/e2e/services/test_hold_integration.py
@@ -1,8 +1,20 @@
 """Integration tests for hold operations."""
 
+import json
+from typing import Literal
+
 import pytest
 
+from pyazul import PyAzul
+from pyazul.core.config import AzulSettings
+from pyazul.models.datavault import TokenRequest, TokenSuccess
 from pyazul.models.payment import Hold
+from pyazul.models.three_ds import (
+    CardHolderInfo,
+    ChallengeIndicator,
+    SecureTokenHold,
+    ThreeDSAuth,
+)
 from tests.fixtures.cards import get_card
 from tests.fixtures.order import generate_order_number
 
@@ -48,3 +60,212 @@ async def test_hold_transaction(transaction_service_integration, hold_transactio
     # Verify we got required reference numbers
     assert response.get("AuthorizationCode"), "Should receive authorization code"
     assert response.get("RRN"), "Should receive reference number"
+
+
+# Helper function for secure token hold tests
+def _prepare_secure_token_hold_request_data(
+    settings: AzulSettings,
+    data_vault_token: str,
+    order_num: str,
+    card_holder_info: CardHolderInfo,
+    challenge_indicator: ChallengeIndicator,
+    custom_order_id_prefix: str,
+    base_method_url: str,
+    base_term_url: str,
+    amount_value: int = 1000,
+    itbis_value: int = 180,
+    force_no_3ds_flag: Literal["0", "1"] = "0",
+) -> SecureTokenHold:
+    """Create and populate SecureTokenHold."""
+    merchant_id = settings.MERCHANT_ID
+    if merchant_id is None:
+        raise ValueError(
+            "MERCHANT_ID in settings cannot be None for secure token hold tests."
+        )
+
+    return SecureTokenHold(
+        Store=merchant_id,
+        OrderNumber=order_num,
+        CustomOrderId=f"{custom_order_id_prefix}-{order_num}",
+        Amount=str(amount_value),
+        Itbis=str(itbis_value),
+        DataVaultToken=data_vault_token,
+        CardHolderInfo=card_holder_info,
+        ThreeDSAuth=ThreeDSAuth(
+            MethodNotificationUrl=base_method_url,
+            TermUrl=base_term_url,
+            RequestChallengeIndicator=challenge_indicator,
+        ),
+        ForceNo3DS=force_no_3ds_flag,
+    )
+
+
+@pytest.fixture
+def card_holder_info_fixture() -> CardHolderInfo:
+    """Provide a standard CardHolderInfo object for 3DS tests."""
+    return CardHolderInfo(
+        Email="test@example.com",
+        Name="Test Cardholder",
+    )
+
+
+@pytest.fixture
+def azul_fixture(settings) -> PyAzul:
+    """Provide a PyAzul instance for testing."""
+    azul_client = PyAzul(settings=settings)
+    return azul_client
+
+
+@pytest.fixture
+async def created_token_fixture(azul_fixture: PyAzul, settings) -> str:
+    """Create a DataVault token for testing token holds."""
+    card = get_card("MASTERCARD_1")
+    token_request = TokenRequest(
+        CardNumber=card["number"],
+        Expiration=card["expiration"],
+        Store=settings.MERCHANT_ID,
+        TrxType="CREATE",
+    )
+
+    token_response = await azul_fixture.create_token(token_request.model_dump())
+
+    if isinstance(token_response, TokenSuccess):
+        return token_response.DataVaultToken
+    else:
+        pytest.fail(f"Failed to create token: {token_response}")
+
+
+@pytest.mark.asyncio
+async def test_secure_token_hold_frictionless_with_3ds_method(
+    azul_fixture: PyAzul,
+    card_holder_info_fixture: CardHolderInfo,
+    created_token_fixture: str,
+    settings,
+):
+    """Test a frictionless 3DS token hold that involves a 3DS Method."""
+    azul = azul_fixture
+    order_num = generate_order_number()
+    base_dummy_url = "http://localhost:8000/dummy"
+
+    initial_request_data = _prepare_secure_token_hold_request_data(
+        settings=settings,
+        data_vault_token=created_token_fixture,
+        order_num=order_num,
+        card_holder_info=card_holder_info_fixture,
+        challenge_indicator=ChallengeIndicator.NO_CHALLENGE,
+        custom_order_id_prefix="3ds-token-hold-frictionless-method",
+        base_method_url=f"{base_dummy_url}/method",
+        base_term_url=f"{base_dummy_url}/term",
+        force_no_3ds_flag="0",
+    )
+
+    initial_response_dict = await azul.secure_token_hold(
+        initial_request_data.model_dump(exclude_none=True)
+    )
+    assert initial_response_dict is not None
+
+    if (
+        initial_response_dict.get("redirect")
+        and initial_response_dict.get("html")
+        and initial_response_dict.get("id")
+    ):
+        secure_id = initial_response_dict["id"]
+        print(f"Initial 3DS Token Hold requires redirect. ID: {secure_id}")
+
+        session_data = await azul.get_session_info(secure_id)
+        assert session_data is not None
+        azul_order_id_from_session = session_data.get("azul_order_id")
+        assert azul_order_id_from_session is not None
+
+        stored_term_url = session_data.get("term_url")
+        assert stored_term_url is not None
+        assert f"secure_id={secure_id}" in stored_term_url
+
+        method_response = await azul.process_3ds_method(
+            azul_order_id=azul_order_id_from_session,
+            method_notification_status="RECEIVED",
+        )
+        assert method_response is not None
+
+        if isinstance(method_response, dict) and method_response.get("IsoCode") == "00":
+            print("Token hold approved after 3DS Method (frictionless).")
+            assert method_response.get("ResponseMessage") == "APROBADA"
+            print(f"Hold successful: {method_response}")
+        else:
+            if isinstance(method_response, dict):
+                response_dump = json.dumps(method_response, indent=2)
+            else:
+                response_dump = str(method_response)
+            pytest.fail(
+                f"Expected direct approval for token hold, but got: {response_dump}"
+            )
+    elif (
+        initial_response_dict.get("value")
+        and isinstance(initial_response_dict["value"], dict)
+        and initial_response_dict["value"].get("IsoCode") == "00"
+    ):
+        print("Token hold approved directly (frictionless, no method redirect).")
+        assert initial_response_dict["value"].get("ResponseMessage") == "APROBADA"
+    elif initial_response_dict.get("IsoCode") == "00":
+        print("Token hold approved directly (frictionless, no redirect).")
+        assert initial_response_dict.get("ResponseMessage") == "APROBADA"
+    else:
+        response_dump = str(initial_response_dict)
+        pytest.fail(
+            f"Expected 3DS Method redirect or direct approval. Got: {response_dump}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_secure_token_hold_complete_workflow(
+    azul_fixture: PyAzul,
+    card_holder_info_fixture: CardHolderInfo,
+    created_token_fixture: str,
+    settings,
+):
+    """Test complete secure token hold workflow."""
+    azul = azul_fixture
+    order_num = generate_order_number()
+    base_dummy_url = "http://localhost:8000/dummy"
+
+    initial_request_data = _prepare_secure_token_hold_request_data(
+        settings=settings,
+        data_vault_token=created_token_fixture,
+        order_num=order_num,
+        card_holder_info=card_holder_info_fixture,
+        challenge_indicator=ChallengeIndicator.CHALLENGE,
+        custom_order_id_prefix="3ds-token-hold-complete",
+        base_method_url=f"{base_dummy_url}/method",
+        base_term_url=f"{base_dummy_url}/term",
+        force_no_3ds_flag="0",
+    )
+
+    # Step 1: Initial secure token hold
+    initial_response_dict = await azul.secure_token_hold(
+        initial_request_data.model_dump(exclude_none=True)
+    )
+
+    assert initial_response_dict is not None
+
+    # Validate the complete workflow structure
+    if initial_response_dict.get("redirect"):
+        secure_id = initial_response_dict["id"]
+        print(f"Token hold initiated with 3DS flow. Secure ID: {secure_id}")
+
+        # Validate session data
+        session_data = await azul.get_session_info(secure_id)
+        assert session_data is not None
+        assert session_data.get("azul_order_id")
+        print(
+            f"Session data stored for token hold: {session_data.get('azul_order_id')}"
+        )
+
+    elif initial_response_dict.get("IsoCode") == "00":
+        print("Token hold completed with direct approval (frictionless)")
+        assert initial_response_dict.get("ResponseMessage") == "APROBADA"
+
+    else:
+        # For any other response, log it for debugging
+        print(f"Token hold response: {initial_response_dict}")
+
+    print("Secure token hold workflow completed successfully")

--- a/tests/unit/models/test_three_ds.py
+++ b/tests/unit/models/test_three_ds.py
@@ -1,0 +1,242 @@
+"""Unit tests for 3D Secure models."""
+
+import pytest
+from pydantic import ValidationError
+
+from pyazul.models.three_ds import (
+    CardHolderInfo,
+    ChallengeIndicator,
+    SecureTokenHold,
+    ThreeDSAuth,
+)
+
+
+class TestSecureTokenHold:
+    """Tests for SecureTokenHold model."""
+
+    def test_secure_token_hold_valid_data(self):
+        """Test creating SecureTokenHold with valid data."""
+        cardholder = CardHolderInfo(
+            Name="Test User",
+            Email="test@example.com",
+        )
+
+        three_ds_auth = ThreeDSAuth(
+            TermUrl="https://example.com/term",
+            MethodNotificationUrl="https://example.com/method",
+            RequestChallengeIndicator=ChallengeIndicator.CHALLENGE,
+        )
+
+        token_hold = SecureTokenHold(
+            Store="39038540035",
+            Amount="1000",
+            Itbis="180",
+            DataVaultToken="6EF85D01-B07C-4E67-99F74E13A449DCDD",
+            OrderNumber="TEST001",
+            CardHolderInfo=cardholder,
+            ThreeDSAuth=three_ds_auth,
+        )
+
+        assert token_hold.Store == "39038540035"
+        assert token_hold.Amount == "1000"
+        assert token_hold.Itbis == "180"
+        assert token_hold.DataVaultToken == "6EF85D01-B07C-4E67-99F74E13A449DCDD"
+        assert token_hold.OrderNumber == "TEST001"
+        assert token_hold.TrxType == "Hold"
+        assert token_hold.Expiration == ""
+        assert token_hold.Channel == "EC"
+        assert token_hold.PosInputMode == "E-Commerce"
+
+    def test_secure_token_hold_default_values(self):
+        """Test SecureTokenHold with default values."""
+        cardholder = CardHolderInfo(Name="Test User")
+        three_ds_auth = ThreeDSAuth(
+            TermUrl="https://example.com/term",
+            MethodNotificationUrl="https://example.com/method",
+            RequestChallengeIndicator=ChallengeIndicator.CHALLENGE,
+        )
+
+        token_hold = SecureTokenHold(
+            Store="39038540035",
+            Amount="1000",
+            DataVaultToken="6EF85D01-B07C-4E67-99F74E13A449DCDD",
+            OrderNumber="TEST001",
+            CardHolderInfo=cardholder,
+            ThreeDSAuth=three_ds_auth,
+        )
+
+        # Check default values
+        assert token_hold.Channel == "EC"
+        assert token_hold.PosInputMode == "E-Commerce"
+        assert token_hold.TrxType == "Hold"
+        assert token_hold.Expiration == ""
+        assert token_hold.ForceNo3DS == "0"
+        assert token_hold.AcquirerRefData == "1"
+
+    def test_secure_token_hold_required_fields(self):
+        """Test that SecureTokenHold validates required fields."""
+        with pytest.raises(ValidationError) as exc_info:
+            SecureTokenHold()  # type: ignore
+
+        errors = exc_info.value.errors()
+        required_fields = [
+            error["loc"][0] for error in errors if error["type"] == "missing"
+        ]
+
+        # Check that required fields are validated
+        assert "Store" in required_fields
+        assert "Amount" in required_fields
+        assert "DataVaultToken" in required_fields
+        assert "OrderNumber" in required_fields
+        assert "CardHolderInfo" in required_fields
+        assert "ThreeDSAuth" in required_fields
+
+    def test_secure_token_hold_trx_type_validation(self):
+        """Test that TrxType field only accepts 'Hold'."""
+        cardholder = CardHolderInfo(Name="Test User")
+        three_ds_auth = ThreeDSAuth(
+            TermUrl="https://example.com/term",
+            MethodNotificationUrl="https://example.com/method",
+            RequestChallengeIndicator=ChallengeIndicator.CHALLENGE,
+        )
+
+        # Should raise validation error for invalid TrxType
+        with pytest.raises(ValidationError) as exc_info:
+            SecureTokenHold(
+                Store="39038540035",
+                Amount="1000",
+                DataVaultToken="6EF85D01-B07C-4E67-99F74E13A449DCDD",
+                OrderNumber="TEST001",
+                TrxType="Sale",  # Invalid for token hold
+                CardHolderInfo=cardholder,
+                ThreeDSAuth=three_ds_auth,
+            )
+
+        errors = exc_info.value.errors()
+        pattern_error = next(
+            (e for e in errors if e["type"] == "string_pattern_mismatch"), None
+        )
+        assert pattern_error is not None
+
+    def test_secure_token_hold_token_validation(self):
+        """Test DataVaultToken format validation."""
+        cardholder = CardHolderInfo(Name="Test User")
+        three_ds_auth = ThreeDSAuth(
+            TermUrl="https://example.com/term",
+            MethodNotificationUrl="https://example.com/method",
+            RequestChallengeIndicator=ChallengeIndicator.CHALLENGE,
+        )
+
+        # Should raise validation error for invalid token format
+        with pytest.raises(ValidationError) as exc_info:
+            SecureTokenHold(
+                Store="39038540035",
+                Amount="1000",
+                DataVaultToken="invalid-token",  # Invalid format
+                OrderNumber="TEST001",
+                CardHolderInfo=cardholder,
+                ThreeDSAuth=three_ds_auth,
+            )
+
+        errors = exc_info.value.errors()
+        pattern_error = next(
+            (e for e in errors if e["type"] == "string_pattern_mismatch"), None
+        )
+        assert pattern_error is not None
+
+    def test_secure_token_hold_force_no_3ds_validation(self):
+        """Test ForceNo3DS field validation."""
+        cardholder = CardHolderInfo(Name="Test User")
+        three_ds_auth = ThreeDSAuth(
+            TermUrl="https://example.com/term",
+            MethodNotificationUrl="https://example.com/method",
+            RequestChallengeIndicator=ChallengeIndicator.CHALLENGE,
+        )
+
+        # Should raise validation error for invalid ForceNo3DS value
+        with pytest.raises(ValidationError) as exc_info:
+            SecureTokenHold(
+                Store="39038540035",
+                Amount="1000",
+                DataVaultToken="6EF85D01-B07C-4E67-99F74E13A449DCDD",
+                OrderNumber="TEST001",
+                ForceNo3DS="2",  # Invalid value
+                CardHolderInfo=cardholder,
+                ThreeDSAuth=three_ds_auth,
+            )
+
+        errors = exc_info.value.errors()
+        pattern_error = next(
+            (e for e in errors if e["type"] == "string_pattern_mismatch"), None
+        )
+        assert pattern_error is not None
+
+    def test_secure_token_hold_optional_fields(self):
+        """Test SecureTokenHold with optional fields."""
+        cardholder = CardHolderInfo(
+            Name="Test User",
+            Email="test@example.com",
+            BillingAddressCity="Test City",
+        )
+
+        three_ds_auth = ThreeDSAuth(
+            TermUrl="https://example.com/term",
+            MethodNotificationUrl="https://example.com/method",
+            RequestChallengeIndicator=ChallengeIndicator.NO_CHALLENGE,
+        )
+
+        token_hold = SecureTokenHold(
+            Store="39038540035",
+            Amount="1000",
+            Itbis="180",
+            DataVaultToken="6EF85D01-B07C-4E67-99F74E13A449DCDD",
+            OrderNumber="TEST001",
+            CustomOrderId="CUSTOM001",
+            CVC="123",
+            CardNumber="4111111111111111",
+            CardHolderInfo=cardholder,
+            ThreeDSAuth=three_ds_auth,
+        )
+
+        assert token_hold.CustomOrderId == "CUSTOM001"
+        assert token_hold.CVC == "123"
+        assert token_hold.CardNumber == "4111111111111111"
+
+    def test_secure_token_hold_model_dump(self):
+        """Test model serialization with exclude_none."""
+        cardholder = CardHolderInfo(
+            Name="Test User",
+            Email="test@example.com",
+        )
+
+        three_ds_auth = ThreeDSAuth(
+            TermUrl="https://example.com/term",
+            MethodNotificationUrl="https://example.com/method",
+            RequestChallengeIndicator=ChallengeIndicator.CHALLENGE,
+        )
+
+        token_hold = SecureTokenHold(
+            Store="39038540035",
+            Amount="1000",
+            DataVaultToken="6EF85D01-B07C-4E67-99F74E13A449DCDD",
+            OrderNumber="TEST001",
+            CardHolderInfo=cardholder,
+            ThreeDSAuth=three_ds_auth,
+        )
+
+        # Serialize with exclude_none=True (as used in the service)
+        data = token_hold.model_dump(exclude_none=True)
+
+        # Required fields should be present
+        assert "Store" in data
+        assert "Amount" in data
+        assert "DataVaultToken" in data
+        assert "OrderNumber" in data
+        assert "TrxType" in data
+        assert "CardHolderInfo" in data
+        assert "ThreeDSAuth" in data
+
+        # Optional fields with None values should be excluded
+        assert "Itbis" not in data or data["Itbis"] is not None
+        assert "CVC" not in data or data["CVC"] is not None
+        assert "CardNumber" not in data or data["CardNumber"] is not None

--- a/tests/unit/services/test_secure_service_unit.py
+++ b/tests/unit/services/test_secure_service_unit.py
@@ -417,6 +417,7 @@ async def test_process_token_hold_with_3ds_method(
     """Test process_token_hold with 3DS method response."""
     # Mock API response for 3DS method
     api_client._async_request.return_value = {
+        "IsoCode": "3D2METHOD",
         "ResponseMessage": "3D_SECURE_2_METHOD",
         "AzulOrderId": "67890",
         "ThreeDSMethod": {


### PR DESCRIPTION
## Add SecureTokenHold Functionality for Token-Based Pre-Authorization

### Summary
This PR implements SecureTokenHold functionality in PyAzul, enabling pre-authorization (hold) transactions using saved payment tokens with full 3D Secure authentication support.

### 🚀 **New Feature: SecureTokenHold**

#### **Core Implementation**
- **SecureTokenHold model** in `pyazul.models.three_ds`
- Support for token-based hold transactions with 3D Secure authentication
- Integration with existing DataVault token infrastructure
- Compatible with manual capture workflows in payment providers

#### **Key Capabilities**
- **Pre-authorize payments** using saved tokens without immediate capture
- **3D Secure authentication** for token hold transactions
- **Validation and error handling** for secure payment processing
- **Flexible challenge flows** supporting method notifications and challenges
- **Session management** for complex 3DS authentication workflows

#### **Model Features**
- Required fields: Store, Amount, DataVaultToken, OrderNumber, CardHolderInfo, ThreeDSAuth
- Validated TrxType field (must be "Hold")
- DataVaultToken format validation with UUID pattern
- ForceNo3DS control ("0" or "1")
- Optional fields: Itbis, CVC, CardNumber, CustomOrderId

### 🧪 **Comprehensive Test Coverage**

#### **Unit Tests** (8 test cases)
- Model validation and serialization
- Required field enforcement  
- Pattern validation for critical fields
- Default value verification

#### **Service Tests** (5 test cases)
- 3DS authentication workflows
- Challenge and method notification handling
- Error scenarios and edge cases
- Complete token hold processing

#### **Integration Tests** (3 test cases)
- Real API interaction with Azul servers
- End-to-end token hold workflows
- Session data management and validation

### 🎯 **Use Cases**
- **E-commerce pre-authorization**: Hold funds at order time, capture at fulfillment
- **Subscription renewals**: Authorize recurring payments using saved tokens
- **Manual review workflows**: Pre-authorize high-value transactions for review
- **Inventory management**: Hold payment while confirming product availability

### 🔧 **Technical Details**
- Extends existing 3DS authentication framework
- Compatible with current SecureSale and SecureTokenSale implementations
- Follows established PyAzul patterns for async operations
- Supports both frictionless and challenge-based 3DS flows
